### PR TITLE
build: add test script to ride/api and ride/web

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,12 @@ To run the Web (frontend) server:
 yarn web:start
 ```
 
+To test the code:
+```sh
+yarn api:test
+yarn web:test
+```
+
 To deploy these two servers with **now**:
 
 ```sh

--- a/api/package.json
+++ b/api/package.json
@@ -9,6 +9,7 @@
   },
   "scripts": {
     "start": "node server.js",
-    "deploy": "now"
+    "deploy": "now",
+    "test": "exit 0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -7,7 +7,9 @@
     "clean": "rm -rf node_modules yarn.lock web/node_modules api/node_modules",
     "api:start": "yarn workspace @ride/api start",
     "api:deploy": "cp yarn.lock api/ && yarn workspace @ride/api deploy",
+    "api:test": "yarn workspace @ride/api test",
     "web:start": "yarn workspace @ride/web start",
-    "web:deploy": "cp yarn.lock web/ && yarn workspace @ride/web deploy"
+    "web:deploy": "cp yarn.lock web/ && yarn workspace @ride/web deploy",
+    "web:test": "yarn workspace @ride/web test"
   }
 }


### PR DESCRIPTION
The test script for the `api` right now only returns a success exit code until we setup a test runner (jest or other)