### PR TITLE
fix: package engines to match ci

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "web:test": "yarn workspace @ride/web test"
   },
   "engines": {
-    "node": "10.11",
-    "yarn": ">=1.10.0"
+    "node": ">=10.10",
+    "yarn": ">=1.9"
   }
 }

--- a/package.json
+++ b/package.json
@@ -11,5 +11,9 @@
     "web:start": "yarn workspace @ride/web start",
     "web:deploy": "cp yarn.lock web/ && yarn workspace @ride/web deploy",
     "web:test": "yarn workspace @ride/web test"
+  },
+  "engines": {
+    "node": "10.11",
+    "yarn": ">=1.10.0"
   }
 }


### PR DESCRIPTION
This fixes the engines to match the CI and the future, the build proceeds and then fails on the `api:test` now. This is safe to merge in the feature branch.